### PR TITLE
terminology; math; with open idiom; Py3k support

### DIFF
--- a/ghettodometer.py
+++ b/ghettodometer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function, division
 
 # oh god why did I write this in python
 # Marcus is going to look at it
@@ -6,32 +7,34 @@
 # nooooo
 # NOOOOOOOOOO
 
+
 import sys
 
+from math import pi
+
 if len(sys.argv) < 3:
-  print "ghettodometer.py <filename> <wheel diameter>"
+  print "ghettodometer.py <filename> <wheel radius>"
   print " (measure center of hub to ground)"
   sys.exit(1)
 
 filename = sys.argv[1]
-wheel_diameter = float(sys.argv[2])
+wheel_radius = float(sys.argv[2])
 
 first = 0
 last = 0
 revolutions = 0
 
-f = open(filename, 'r')
-for line in f:
-  if not first:
-    first = int(line)
-  revolutions = revolutions+1
-  last = int(line)
+with open(filename, 'r') as f:
+  for line in f:
+    if not first:
+      first = int(line)
+    revolutions = revolutions+1
+    last = int(line)
 
-print "Assuming %0.02f cm from center of hub to ground..." % (wheel_diameter)
+print("Assuming %0.02f cm from center of hub to ground..." % (wheel_radius))
 
 # figure distance traveled
-pi = 3.1415
-circumference = wheel_diameter * 2.0 * pi
+circumference = wheel_radius * 2 * pi
 distance = circumference * revolutions
 km = distance / 100000
 
@@ -39,13 +42,13 @@ km = distance / 100000
 elapsed = last - first
 
 # figure kph
-secs = elapsed / 1000.0
+secs = elapsed / 1000
 hours = secs / 3600
 kph = km / hours
 
-print "traveled %0.02f km in %0.02f hours (%0.02f kph)" % (km, hours, kph)
+print("traveled %0.02f km in %0.02f hours (%0.02f kph)" % (km, hours, kph))
    
 miles = km * 0.621371 
 mph = miles / hours
 
-print "for us silly americans, that's %0.02f miles (%0.02f mph)" % (miles, mph)
+print("for us silly americans, that's %0.02f miles (%0.02f mph)" % (miles, mph))


### PR DESCRIPTION
- changed diameter to radius so it's less confusing
- math.pi is more pi than pi = 3.1415
- with open ... idiom is cleaner
- now it should work on both Python 2 and 3
